### PR TITLE
Tidy up test and skip if LWP::ConsoleLogger::Easy < 0.000028.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,6 +27,7 @@ my %WriteMakefileArgs = (
   },
   "TEST_REQUIRES" => {
     "Test2::Bundle::More" => 0,
+    "Test::Needs" => 0,
     "Test::RequiresInternet" => 0,
     "strict" => 0,
     "warnings" => 0

--- a/cpanfile
+++ b/cpanfile
@@ -9,6 +9,7 @@ requires "perl" => "5.006";
 
 on 'test' => sub {
   requires "Test2::Bundle::More" => "0";
+  requires "Test::Needs" => "0";
   requires "Test::RequiresInternet" => "0";
   requires "perl" => "5.006";
   requires "strict" => "0";

--- a/t/WebService/SQLFormat.t
+++ b/t/WebService/SQLFormat.t
@@ -5,6 +5,7 @@ use Test::RequiresInternet( 'sqlformat.org' => 80 );
 use Test2::Bundle::More;
 
 use WebService::SQLFormat;
+use Test::Needs { 'LWP::ConsoleLogger::Easy' => '0.000028' };
 
 my $f = WebService::SQLFormat->new( debug_level => $ENV{AUTHOR_TESTING}
         && !$ENV{TRAVIS} ? 11 : 0, reindent => 1, );


### PR DESCRIPTION
Hi @oalders 

Please review the PR.
It address the following issue:

     manwar@ubuntu:~/github/webservice-sqlformat$ make test
     PERL_DL_NONLAZY=1 "/usr/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" 
     "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')
     " t/*.t t/WebService/*.t
     t/WebService/SQLFormat.t .. 1/? LWP::ConsoleLogger::Easy version 0.000028 required--this is 
     only version 0.000023 at /usr/local/share/perl/5.18.2/Module/Runtime.pm line 349, <DATA> line 1.
     # Tests were run but no plan was declared and done_testing() was not seen.
     # Looks like your test exited with 255 after test #2.
     t/WebService/SQLFormat.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
     All 2 subtests passed 

     Test Summary Report
     -------------------
     t/WebService/SQLFormat.t (Wstat: 65280 Tests: 2 Failed: 0)
     Non-zero exit status: 255
     Parse errors: No plan found in TAP output
     Files=1, Tests=2,  1 wallclock secs ( 0.05 usr  0.01 sys +  0.58 cusr  0.22 csys =  0.86 CPU)
     Result: FAIL
     Failed 1/1 test programs. 0/2 subtests failed.
     make: *** [test_dynamic] Error 255

Many Thanks.
Best Regards,
Mohammad S Anwar